### PR TITLE
Fixed: root.aggregates => root.aggregate in build.sbt

### DIFF
--- a/src/main/g8/$project_name$/build.sbt
+++ b/src/main/g8/$project_name$/build.sbt
@@ -24,7 +24,7 @@ lazy val root = (project in file("."))
     name := props.ProjectName
   )
   .settings(noPublish)
-  .aggregates(core, app)
+  .aggregate(core, app)
 
 lazy val core = subProject("core", file("core"))
   .settings(


### PR DESCRIPTION
Fixed: `root.aggregates` => `root.aggregate` in `build.sbt`