### PR TITLE
Updated: build.sbt - old sbt syntax ( in ) to the new one ( / )

### DIFF
--- a/src/main/g8/$project_name$/build.sbt
+++ b/src/main/g8/$project_name$/build.sbt
@@ -100,10 +100,10 @@ def subProject(projectName: String, file: File): Project =
     )
 
 lazy val debianPackageInfo: SettingsDefinition = List(
-  maintainer in Linux := "$author_name$ <$author_email$>",
-  packageSummary in Linux := "My App",
+  Linux / maintainer := "$author_name$ <$author_email$>",
+  Linux / packageSummary := "My App",
   packageDescription := "My app is ...",
-  serverLoading in Debian := SystemV.some,
+  Debian / serverLoading := SystemV.some,
 )
 
 lazy val noPublish: SettingsDefinition = List(


### PR DESCRIPTION
Updated: build.sbt - old sbt syntax (` in `) to the new one (` / `)